### PR TITLE
Implement addAttachmentToCard function

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,6 +69,13 @@ Trello.prototype.addCommentToCard = function (cardId, comment, callback) {
     makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/actions/comments', {query: query}, callback);
 };
 
+Trello.prototype.addAttachmentToCard = function (cardId, url, callback) {
+    var query = this.createQuery();
+    query.url = url;
+
+    makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/attachments', {query: query}, callback);
+};
+
 Trello.prototype.addMemberToCard = function (cardId, memberId, callback) {
     var query = this.createQuery();
     query.value = memberId;

--- a/test/spec.js
+++ b/test/spec.js
@@ -272,4 +272,36 @@ describe('Trello', function () {
             cardsCreated.should.equal(cardsToCreate);
         });
     });
+
+    describe('addAttachmentToCard', function() {
+        var query;
+        var post;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'post', function (uri, options) {
+                return {on: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.addAttachmentToCard('myCardId', 'attachmentUrl', function () {
+                query = restler.post.args[0][1].query;
+                post = restler.post;
+                done();
+            });
+        });
+
+        it("should post to the card's attachment URI", function () {
+            post.should.have.been.calledWith('https://api.trello.com/1/cards/myCardId/attachments');
+        });
+
+        it('should include the list id', function () {
+            query.url.should.equal('attachmentUrl');
+        });
+
+        afterEach(function () {
+            restler.post.restore();
+        });
+    });
+
 });


### PR DESCRIPTION
Following the style of the code so far, I based this on the existing
addMemberToCard function.  This lets you add an attachment to a card by
specifying a URL starting with http:// or https:// and is the simplest
way to add attachments in Trello.  This resolves #2 and is significantly
simpler than PR #11 (although that also allows you to upload files).