### PR TITLE
Expect makeRequest's fn to complete only once

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ Trello.prototype.createQuery = function () {
 
 function makeRequest(fn, uri, options, callback) {
     fn(uri, options)
-        .on('complete', function (result) {
+        .once('complete', function (result) {
             if (result instanceof Error) {
                 callback(result);
             } else {

--- a/test/spec.js
+++ b/test/spec.js
@@ -20,7 +20,7 @@ describe('Trello', function () {
 
         beforeEach(function (done) {
             sinon.stub(restler, 'post', function (uri, options) {
-                return {on: function (event, callback) {
+                return {once: function (event, callback) {
                     callback(null, null);
                 }};
             });
@@ -59,7 +59,7 @@ describe('Trello', function () {
 
         beforeEach(function (done) {
             sinon.stub(restler, 'post', function (uri, options) {
-                return {on: function (event, callback) {
+                return {once: function (event, callback) {
                     callback(null, null);
                 }};
             });
@@ -100,7 +100,7 @@ describe('Trello', function () {
         beforeEach(function (done) {
             sinon.stub(restler, 'post', function (uri, options) {
                 return {
-                    on: function (event, callback) {
+                    once: function (event, callback) {
                         callback(null, null);
                     }
                 };
@@ -148,7 +148,7 @@ describe('Trello', function () {
         beforeEach(function (done) {
             sinon.stub(restler, 'del', function (uri, options) {
                 return {
-                    on: function (event, callback) {
+                    once: function (event, callback) {
                         callback(null, null);
                     }
                 };
@@ -184,7 +184,7 @@ describe('Trello', function () {
         beforeEach(function (done) {
             sinon.stub(restler, 'put', function (uri, options) {
                 return {
-                    on: function (event, callback) {
+                    once: function (event, callback) {
                         callback(null, null);
                     }
                 };


### PR DESCRIPTION
An HTTP request only completes once, therefore it is sufficient to
attach a one-time listener .once() to fn, which will be removed once
triggered and does not count towards the max listeners count like .on().
This solves #5, albeit in a less drastic manner than PR #10.

The tests have also been updated to fire "once: complete" events instead
of "on: complete". However, in practice, older versions of the restler
library did not inherit properly from node's Event, and would fire
'complete' more than once, therefore also breaking the one-time
listener, so this commit depends on issue #9 (for an updated restler
version) to work correctly.