### PR TITLE
Get off Travis's "legacy infrastructure"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - 0.6
   - 0.8


### PR DESCRIPTION
Explicitly setting "sudo: false" is enough to be compatible with Travis
CI's new infrastructure: http://docs.travis-ci.com/user/migrating-from-legacy