### PR TITLE
Include node v4.0.0 in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
+  - 4.0
   - 0.12
   - 0.11
   - 0.10


### PR DESCRIPTION
New version of node came out yesterday, v4 following the io.js merge. It's in nvm already and the tests seem run fine in it, so why not include it! :+1: