### PR TITLE
Api additions

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,7 +197,7 @@ Trello.prototype.deleteWebhook = function (webHookId, callback) {
 };
 
 Trello.prototype.getLabelsForBoard = function(boardId, callback) {
-    makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/labels', {query:this.createQuery()}, callback);
+    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/labels', {query:this.createQuery()}, callback);
 };
 
 Trello.prototype.addLabelOnBoard = function(boardId, name, color, callback) {
@@ -208,36 +208,36 @@ Trello.prototype.addLabelOnBoard = function(boardId, name, color, callback) {
         name: name
     };
 
-    makeRequest(rest.post, this.uri + '/1/labels', {data: data, query:query}, callback);
+    return makeRequest(rest.post, this.uri + '/1/labels', {data: data, query:query}, callback);
 };
 
 Trello.prototype.deleteLabel = function(labelId, callback) {
-    makeRequest(rest.del, this.uri + '/1/labels/' + labelId, {query: this.createQuery()}, callback);
+    return makeRequest(rest.del, this.uri + '/1/labels/' + labelId, {query: this.createQuery()}, callback);
 };
 
 Trello.prototype.addLabelToCard = function(cardId, labelId, callback) {
     var query = this.createQuery();
     var data = { value: labelId };
-    makeRequest(rest.post, this.uri+'/1/cards/' + cardId + '/idLabels', {query:query, data:data}, callback);
+    return makeRequest(rest.post, this.uri+'/1/cards/' + cardId + '/idLabels', {query:query, data:data}, callback);
 };
 
 Trello.prototype.deleteLabelFromCard = function(cardId, labelId, callback){
-    makeRequest(rest.del, this.uri + '/1/cards/' + cardId + '/idLabels/'+labelId, {query: this.createQuery()}, callback);
+    return makeRequest(rest.del, this.uri + '/1/cards/' + cardId + '/idLabels/'+labelId, {query: this.createQuery()}, callback);
 };
 
 Trello.prototype.updateLabel = function (labelId, field, value, callback) {
     var query = this.createQuery();
     query.value = value;
 
-    makeRequest(rest.put, this.uri + '/1/labels/' + labelId + '/' + field, {query: query}, callback);
+    return makeRequest(rest.put, this.uri + '/1/labels/' + labelId + '/' + field, {query: query}, callback);
 }
 
 Trello.prototype.updateLabelName = function (labelId, name, callback) {
-    this.updateLabel(labelId, 'name', name, callback);
+    return this.updateLabel(labelId, 'name', name, callback);
 }
 
 Trello.prototype.updateLabelColor = function (labelId, color, callback) {
-    this.upadateLabel(labelId, 'color', color, callback);
+    return this.upadateLabel(labelId, 'color', color, callback);
 }
 
 

--- a/main.js
+++ b/main.js
@@ -108,6 +108,13 @@ Trello.prototype.getBoards = function(memberId, callback) {
     return makeRequest(rest.get, this.uri + '/1/members/' + memberId + '/boards', {query: this.createQuery()}, callback);
 };
 
+Trello.prototype.addChecklistToCard = function (cardId, name, callback) {
+    var query = this.createQuery();
+    query.name = name
+    
+    return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/checklists', { query: query }, callback);
+}
+
 Trello.prototype.addItemToChecklist = function (checkListId, name, callback) {
     var query = this.createQuery();
     query.name = name;

--- a/main.js
+++ b/main.js
@@ -115,9 +115,14 @@ Trello.prototype.addChecklistToCard = function (cardId, name, callback) {
     return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/checklists', { query: query }, callback);
 }
 
-Trello.prototype.addItemToChecklist = function (checkListId, name, callback) {
+Trello.prototype.getChecklistsOnCard = function (cardId, callback) {    
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/checklists', {query: this.createQuery()}, callback);
+}
+
+Trello.prototype.addItemToChecklist = function (checkListId, name, pos, callback) {
     var query = this.createQuery();
     query.name = name;
+    query.pos = pos;
 
     return makeRequest(rest.post, this.uri + '/1/checklists/' + checkListId + '/checkitems', {query: query}, callback);
 };
@@ -129,16 +134,23 @@ Trello.prototype.updateCard = function (cardId, field, value, callback) {
     return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + '/' + field, {query: query}, callback);
 };
 
+Trello.prototype.updateChecklist = function (checklistId, field, value, callback) {
+    var query = this.createQuery();
+    query.value = value;
+
+    return makeRequest(rest.put, this.uri + '/1/checklists/' + checklistId + '/' + field, {query: query}, callback);
+};
+
 Trello.prototype.updateCardName = function (cardId, name, callback) {
-    this.updateCard(cardId, 'name', name, callback);
+    return this.updateCard(cardId, 'name', name, callback);
 };
 
 Trello.prototype.updateCardDescription = function (cardId, description, callback) {
-    this.updateCard(cardId, 'desc', description, callback);
+    return this.updateCard(cardId, 'desc', description, callback);
 };
 
 Trello.prototype.updateCardList = function (cardId, listId, callback) {
-    this.updateCard(cardId, 'idList', listId, callback);
+    return this.updateCard(cardId, 'idList', listId, callback);
 };
 
 Trello.prototype.getBoardMembers = function (boardId, callback) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -370,6 +370,10 @@ describe('Trello', function () {
         it('should get to https://api.trello.com/1/boards/boardId/labels', function () {
             get.should.have.been.calledWith('https://api.trello.com/1/boards/boardId/labels');
         });
+        
+        afterEach(function () {
+            restler.get.restore();
+        });
     });
 
 
@@ -556,6 +560,62 @@ describe('Trello', function () {
 
         afterEach(function () {
             restler.post.restore();
+        });
+    });
+    
+    describe('getChecklistsOnCard', function() {
+        var get;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getChecklistsOnCard('cardId', function () {
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get to https://api.trello.com/1/cards/cardId/checklists', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/cards/cardId/checklists');
+        });
+        
+        afterEach(function () {
+            restler.get.restore();
+        });
+    });
+    
+    describe('updateChecklist', function() {
+        var query;
+        var put;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'put', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.updateChecklist('checklistId', 'field', 'value', function () {
+                query = restler.put.args[0][1].query;
+                put = restler.put;
+                done();
+            });
+        });
+
+        it('should put to https://api.trello.com/1/checklists/checklistId/field', function () {
+            put.should.have.been.calledWith('https://api.trello.com/1/checklists/checklistId/field');
+        });
+
+        it('should include the checklist name', function () {
+            query.value.should.equal('value');
+        });
+
+        afterEach(function () {
+            restler.put.restore();
         });
     });
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -527,4 +527,35 @@ describe('Trello', function () {
             restler.put.restore();
         });
     });
+    
+    describe('addChecklistToCard', function() {
+        var query;
+        var post;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'post', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.addChecklistToCard('cardId', 'name', function () {
+                query = restler.post.args[0][1].query;
+                post = restler.post;
+                done();
+            });
+        });
+
+        it('should post to https://api.trello.com/1/cards/cardId/checklists', function () {
+            post.should.have.been.calledWith('https://api.trello.com/1/cards/cardId/checklists');
+        });
+
+        it('should include the checklist name', function () {
+            query.name.should.equal('name');
+        });
+
+        afterEach(function () {
+            restler.post.restore();
+        });
+    });
 });


### PR DESCRIPTION
I've added various missing APIs I needed, with tests. Cleaned up the return values of a couple existing ones, so they return the promise too. Possibly the only problem is I've had to make a breaking change to the API for `addItemToChecklist`. I've added the pos parameter for the 3rd param (to be consistent I didn't want to add it after the callback param). A bit of code such as this could be added, which would mean the old API still worked.
```javascript
if (typeof pos === 'number') {
    query.pos = pos;
} else if (typeof pos === 'function' && callback === 'undefined') {
    // deals with a breaking api change, if 3rd argment 'pos' is a function and 4th is undefined. we are using the old api, so set callback to the pos.
    callback = pos;
}
```