### PR TITLE
Added rate limiting for callback or promise usage. Trello limits requ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ API calls can either execute a callback or return a promise. To return a promise
   })
 ```
 
+## Rate limiting
+Trello limits it's APIs at [100 requests per 10 second interval for each token](http://help.trello.com/article/838-api-rate-limits). To change the limits from the default (100 requests per 10 second), modify the `limits` object.
+
+```javascript
+  var Trello = require("trello");
+  
+  Trello.limits.count = x;
+  Trello.limits.time = y;
+```
+
+By default limiting is turned off. To enable toggle the `limitRate` property.
+```javascript
+  var Trello = require("trello");
+  
+  Trello.limitRate = true; // now rate limited.
+  
+  // ...
+  
+  Trello.limitRate = false; // no longer rate limited.
+```
+
+*Note: changes to `count` and `time` properties only take effect after `limitRate` has been toggled.*
+
 ## History
 
 ### 0.5.0

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "trello"
   ],
   "dependencies": {
+    "es6-promise": "~3.0.2",
     "restler": "~3.3.0",
-    "es6-promise": "~3.0.2"
+    "simple-rate-limiter": "^0.2.3"
   },
   "devDependencies": {
     "mocha": "~2.3.2",


### PR DESCRIPTION
I've been making a bulk uploader into trello, and hit the trello api rate limit. Thought it might be something nice to put into this project so added simple-rate-limiter module (no license and requires node v0.10.1+, project has tests). By default it is turned off, but the config is set at the token/key rate of 100 per 10 second interval. I've made it wrap both callback and promise APIs. There's some tests to check it works both rate limited and non rate limited. Plus updated the README.

If its something you want in the project, feel free to merge.
