### PR TITLE
fix name query param to value

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,7 +105,7 @@ Trello.prototype.getCardsForList = function(listId, actions, callback) {
 
 Trello.prototype.renameList = function (listId, name, callback) {
     var query = this.createQuery();
-    query.name = name;
+    query.value = name;
 
     return makeRequest(rest.put, this.uri + '/1/lists/' + listId + '/name', {query: query}, callback);
 };

--- a/test/spec.js
+++ b/test/spec.js
@@ -411,7 +411,7 @@ describe('Trello', function () {
         });
 
         it('should include the new list name', function () {
-            query.name.should.equal('new list name');
+            query.value.should.equal('new list name');
         });
 
         afterEach(function () {


### PR DESCRIPTION
I've updated the renameList method to reflect the last API version here [https://developers.trello.com/advanced-reference/list#put-1-lists-idlist-name](https://developers.trello.com/advanced-reference/list#put-1-lists-idlist-name) where the query param name is called value.