### PR TITLE
Use updated LTS Node versions for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 sudo: false
 node_js:
   - 4.0
-  - 0.12
-  - 0.11
-  - 0.10
+  - 6.0
 branches:
   only:
     - master


### PR DESCRIPTION
We should update the test configuration to use newer versions of Node because Node versions v0.10 and v0.12 are end-of-life and no longer maintained since October and December 2016 respectively.  Node v4 is currently the oldest LTS version so we should test it and the next LTS, which is v6.  I don't think we need to test "current", but should rather wait until the next LTS v8.

Version 4 will be supported until 2018-04-01, at which point this config might need updating again.