### PR TITLE
Add ability to handle extra parameters when getting cards on boards or lists

### DIFF
--- a/main.js
+++ b/main.js
@@ -266,9 +266,23 @@ Trello.prototype.getCardsOnBoard = function (boardId, callback) {
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards', {query: this.createQuery()}, callback);
 };
 
+Trello.prototype.getCardsOnBoardWithExtraParams = function (boardId, extraParams, callback) {
+    var query = this.createQuery();    
+    Object.assign(query, extraParams);
+
+    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards', {query: query}, callback);
+}
+
 Trello.prototype.getCardsOnList = function (listId, callback) {
     return makeRequest(rest.get, this.uri + '/1/lists/' + listId + '/cards', {query: this.createQuery()}, callback);
 };
+
+Trello.prototype.getCardsOnListWithExtraParams = function (listId, extraParams, callback) {
+    var query = this.createQuery();    
+    Object.assign(query, extraParams);
+
+    return makeRequest(rest.get, this.uri + '/1/lists/' + listId + '/cards', {query: query}, callback);
+}
 
 Trello.prototype.deleteCard = function (cardId, callback) {
     return makeRequest(rest.del, this.uri + '/1/cards/' + cardId, {query: this.createQuery()}, callback);

--- a/test/spec.js
+++ b/test/spec.js
@@ -229,6 +229,72 @@ describe('Trello', function () {
 
     });
 
+    describe('getCardsOnListWithExtraParams', function () {
+        var query;
+        var post;
+
+        var testDate = new Date("2015/03/25");
+        var extraParams = {before: testDate}
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getCardsOnListWithExtraParams('listId', extraParams, function () {
+                query = restler.get.args[0][1].query;
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get from https://api.trello.com/1/lists/listId/cards', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/lists/listId/cards');
+        });
+        it('should include a date in the query', function () {
+            query.before.should.equal(testDate)
+        });
+
+        afterEach(function () {
+            restler.get.restore();
+        });
+    });
+
+    describe('getCardsOnBoardWithExtraParams', function () {
+        var query;
+        var post;
+
+        var testDate = new Date("2015/03/25");
+        var extraParams = {before: testDate}
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getCardsOnBoardWithExtraParams('boardId', extraParams, function () {
+                query = restler.get.args[0][1].query;
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get from https://api.trello.com/1/boards/boardId/cards', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/boards/boardId/cards');
+        });
+        it('should include a date in the query', function () {
+            query.before.should.equal(testDate)
+        });
+
+        afterEach(function () {
+            restler.get.restore();
+        });
+    });
+
     describe('addWebhook', function () {
         var query;
         var post;


### PR DESCRIPTION
This addresses #39 and allows for the use of things like pagination when getting cards.  just like with the "addCardWithExtraParams" function these functions accept an object that contains all additional parameters to add to the request.