### PR TITLE
Fixed typo in test for addAttachmentToCard

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -495,7 +495,7 @@ describe('Trello', function () {
             post.should.have.been.calledWith('https://api.trello.com/1/cards/myCardId/attachments');
         });
 
-        it('should include the list id', function () {
+        it('should include the attachmentUrl', function () {
             query.url.should.equal('attachmentUrl');
         });
 


### PR DESCRIPTION
Minor change to update the description of one of the tests in addAttachmentToCard to reflect the value being passed.