### PR TITLE
Added ability to send all params through addListToBoard

### DIFF
--- a/main.js
+++ b/main.js
@@ -141,9 +141,13 @@ Trello.prototype.renameList = function (listId, name, callback) {
     return makeRequest(rest.put, this.uri + '/1/lists/' + listId + '/name', {query: query}, callback);
 };
 
-Trello.prototype.addListToBoard = function (boardId, name, callback) {
+Trello.prototype.addListToBoard = function (boardId, queryParams, callback) {
     var query = this.createQuery();
-    query.name = name;
+    if (typeof queryParams === 'string') {
+      query.name = queryParams;
+    } else {
+      query = queryParams;
+    }
 
     return makeRequest(rest.post, this.uri + '/1/boards/' + boardId + '/lists', {query: query}, callback);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trello",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "Norbert Eder <opensource@norberteder.com>",
   "description": "This module provides an easy way to make requests to the Trello API.",
   "contributors": [
@@ -24,14 +24,18 @@
       "name": "Siôn Le Roux",
       "email": "sinisterstuf@gmail.com"
     },
-	{
-	  "name": "Mike Garuccio",
-	  "url": "https://github.com/mgaruccio"
-	},
-	{
-	  "name": "Karel Piwko",
-	  "url": "https://github.com/kpiwko"
-	}
+    {
+      "name": "Mike Garuccio",
+      "url": "https://github.com/mgaruccio"
+    },
+    {
+      "name": "Karel Piwko",
+      "url": "https://github.com/kpiwko"
+    },
+    {
+      "name": "Josh Terrill",
+      "url": "https://github.com/joshterrill"
+    }
   ],
   "scripts": {
     "test": "node node_modules/mocha/bin/mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trello",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Norbert Eder <opensource@norberteder.com>",
   "description": "This module provides an easy way to make requests to the Trello API.",
   "contributors": [

--- a/test/spec.js
+++ b/test/spec.js
@@ -1059,4 +1059,39 @@ describe('Trello', function () {
             restler.put.restore();
         });
     });
+
+    describe('addListToBoard', function() {
+        var query;
+        var post;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'post', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.addListToBoard('boardId', {name: 'Board Name', pos: 1}, function () {
+                query = restler.post.args[0][1].query;
+                post = restler.post;
+                done();
+            });
+        });
+
+        it('should post to https://api.trello.com/1/boards/boardId/lists', function () {
+            post.should.have.been.calledWith('https://api.trello.com/1/boards/boardId/lists');
+        });
+
+        it('should include the name', function () {
+            query.name.should.equal('Board Name');
+        });
+
+        it('should include position', function () {
+            query.pos.should.equal(1);
+        });
+
+        afterEach(function () {
+            restler.post.restore();
+        });
+    });
 });


### PR DESCRIPTION
There are more than just the `name` parameter that can be sent through to the `addListToBoard()` API endpoint. So I generically made it so that you can pass an object of parameters through to this method. It's also backwards compatible so it doesn't break anyone else as it does a type check on the param coming through, if it's a string, it assumes you're sending a name through, if it's an object, it sets the query variable equal to what's coming through.