### PR TITLE
Return with error if Trello responds with http status >= 400

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,7 +26,11 @@ function makeRequest(fn, uri, options, callback) {
           }, Math.floor(Math.random() * (maxRequestDelay - minRequestDelay)) + minRequestDelay);
         }
         else if (result instanceof Error) {
-            callback(result);
+            callback(result, null);
+        } else if (response != null && response.statusCode >= 400) {
+            const rv = new Error(result)
+            rv.response = response
+            callback(rv, null)
         } else {
             callback(null, result);
         }
@@ -47,6 +51,10 @@ function makeRequest(fn, uri, options, callback) {
               }
               else if (result instanceof Error) {
                   reject(result);
+              } else if (response != null && response.statusCode >= 400) {
+                  const rv = new Error(result)
+                  rv.response = response
+                  reject(rv)
               } else {
                   resolve(result);
               }


### PR DESCRIPTION
Hey! This is something I made for myself, feel free to reject the PR if it doesn't fit your vision for this project. 

This PR is introducing new behavior when Trello's API returns with an HTTP status code >= 400. Previously, this library would resolve the promise with Trello's error description as its value. This behavior was problematic for me, because I could not distinguish successful from failed responses.

With this change, the promise is rejected, passing Trello's error description as an `Error` object. In addition, the http response object is passed as an attribute on the Error returned to allow introspection of the original http status code etc.

All the best,
Vincent

