### PR TITLE
Add extra params support everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ API calls can either execute a callback or return a promise. To return a promise
   })
 ```
 
+## Passing extra query parameters
+
+Each API call supports passing an optional object before the callback containing extra query parameters:
+
+```javascript
+  //Callback
+  trello.getCardsOnList(listId, { card_members: true }, callback)
+
+  //Promise
+  var cardsPromise = trello.getCardsOnList(listId, { card_members: true })
+  cardsPromise.then((cards) => {
+    //do stuff
+  })
+```
+
 ## Requests to API endpoints, not supported by this lib yet
 
 ```javascript

--- a/main.js
+++ b/main.js
@@ -57,14 +57,14 @@ function makeRequest(fn, uri, options, callback) {
     }
 }
 
-Trello.prototype.makeRequest = function (requestMethod, path, options, callback) {
-    options = options || {};
+Trello.prototype.makeRequest = function (requestMethod, path, query, callback) {
+    query = query || {};
 
     if (typeof requestMethod !== 'string') {
         throw new TypeError("requestMethod should be a string");
     }
-    if (typeof options !== 'object') {
-        throw new TypeError("options should be an object");
+    if (typeof query !== 'object') {
+        throw new TypeError("query should be an object");
     }
 
     var method = requestMethod.toLowerCase();
@@ -79,7 +79,7 @@ Trello.prototype.makeRequest = function (requestMethod, path, options, callback)
         throw new Error("Unsupported requestMethod. Pass one of these methods: POST, GET, PUT, DELETE.");
     }
     var keyTokenObj = this.createQuery();
-    var query = objectAssign({}, options, keyTokenObj);
+    query = objectAssign({}, query, keyTokenObj);
     return makeRequest(methods[method], this.uri + path, {query: query}, callback)
 };
 

--- a/main.js
+++ b/main.js
@@ -83,7 +83,36 @@ Trello.prototype.makeRequest = function (requestMethod, path, query, callback) {
     return makeRequest(methods[method], this.uri + path, {query: query}, callback)
 };
 
-Trello.prototype.addBoard = function (name, description, organizationId, callback) {
+function extractExtraParams(extraParamsOrCallback) {
+    if (typeof extraParamsOrCallback === 'object') {
+        return extraParamsOrCallback
+    } else if (typeof extraParamsOrCallback === 'function') {
+        return {}
+    } else if (typeof extraParamsOrCallback === 'undefined') {
+        return {}
+    } else {
+        throw new Error("Invalid extra params or callback parameter of type " + typeof extraParamsOrCallback)
+    }
+}
+
+function extractCallback(extraParamsOrCallback, callback) {
+    if (typeof extraParamsOrCallback === 'function') {
+        return extraParamsOrCallback
+    } else if (typeof extraParamsOrCallback === 'object') {
+        return callback
+    } else if (typeof extraParamsOrCallback === 'undefined') {
+        return callback
+    } else {
+        throw new Error("Invalid extra params or callback parameter of type " + typeof extraParamsOrCallback)
+    }
+}
+
+function applyExtraParams(extraParamsOrCallback, query) {
+    var extraParams = extractExtraParams(extraParamsOrCallback)
+    return objectAssign({}, extraParams, query)
+}
+
+Trello.prototype.addBoard = function (name, description, organizationId, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.name = name;
 
@@ -92,17 +121,21 @@ Trello.prototype.addBoard = function (name, description, organizationId, callbac
     if (organizationId !== null)
         query.idOrganization = organizationId;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/boards/', {query: query}, callback);
 };
 
-Trello.prototype.updateBoardPref = function (boardId, field, value, callback) {
+Trello.prototype.updateBoardPref = function (boardId, field, value, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = value;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/boards/' + boardId + '/prefs/' + field, {query: query}, callback);
 };
 
-Trello.prototype.addCard = function (name, description, listId, callback) {
+Trello.prototype.addCard = function (name, description, listId, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.name = name;
     query.idList = listId;
@@ -110,185 +143,226 @@ Trello.prototype.addCard = function (name, description, listId, callback) {
     if (description !== null)
         query.desc = description;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/cards', {query: query}, callback);
 };
 
 Trello.prototype.addCardWithExtraParams = function(name, extraParams, listId, callback) {
-    var query = this.createQuery();
-    query.name = name;
-    query.idList = listId;
-
-    Object.assign(query, extraParams);
-
-    return makeRequest(rest.post, this.uri + '/1/cards', {query: query}, callback);
+    return this.addCard(name, null, listId, extraParams, callback)
 };
 
-Trello.prototype.getCard = function (boardId, cardId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards/' + cardId, {query: this.createQuery()}, callback);
+Trello.prototype.getCard = function (boardId, cardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards/' + cardId, {query: query}, callback);
 };
 
-Trello.prototype.getCardsForList = function(listId, actions, callback) {
+Trello.prototype.getCardsForList = function(listId, actions, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     if (actions)
         query.actions = actions;
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.get, this.uri + '/1/lists/' + listId + '/cards', {query: query}, callback);
 };
 
-Trello.prototype.renameList = function (listId, name, callback) {
+Trello.prototype.renameList = function (listId, name, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = name;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/lists/' + listId + '/name', {query: query}, callback);
 };
 
-Trello.prototype.addListToBoard = function (boardId, name, callback) {
+Trello.prototype.addListToBoard = function (boardId, name, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.name = name;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/boards/' + boardId + '/lists', {query: query}, callback);
 };
 
-Trello.prototype.addMemberToBoard = function (boardId, memberId, type, callback) {
+Trello.prototype.addMemberToBoard = function (boardId, memberId, type, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     var data = {type: type}; // Valid Values: 'normal','admin','observer'
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/boards/' + boardId + '/members/' + memberId, { data: data, query: query }, callback);
 };
 
-Trello.prototype.addCommentToCard = function (cardId, comment, callback) {
+Trello.prototype.addCommentToCard = function (cardId, comment, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.text = comment;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/actions/comments', {query: query}, callback);
 };
 
-Trello.prototype.addAttachmentToCard = function (cardId, url, callback) {
+Trello.prototype.addAttachmentToCard = function (cardId, url, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.url = url;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/attachments', {query: query}, callback);
 };
 
-Trello.prototype.addMemberToCard = function (cardId, memberId, callback) {
+Trello.prototype.addMemberToCard = function (cardId, memberId, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = memberId;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/members', {query: query}, callback);
 };
 
-Trello.prototype.getBoards = function(memberId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/members/' + memberId + '/boards', {query: this.createQuery()}, callback);
+Trello.prototype.getBoards = function(memberId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/members/' + memberId + '/boards', {query: query}, callback);
 };
 
-Trello.prototype.getOrgBoards = function (organizationId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/organizations/' + organizationId + '/boards', {query: this.createQuery()}, callback);
+Trello.prototype.getOrgBoards = function (organizationId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/organizations/' + organizationId + '/boards', {query: query}, callback);
 };
 
-Trello.prototype.addChecklistToCard = function (cardId, name, callback) {
+Trello.prototype.addChecklistToCard = function (cardId, name, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.name = name;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/checklists', { query: query }, callback);
 };
 
-Trello.prototype.addExistingChecklistToCard = function (cardId, checklistId, callback) {
+Trello.prototype.addExistingChecklistToCard = function (cardId, checklistId, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.idChecklistSource = checklistId;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/cards/' + cardId + '/checklists', { query: query }, callback);
 };
 
-Trello.prototype.getChecklistsOnCard = function (cardId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/checklists', {query: this.createQuery()}, callback);
+Trello.prototype.getChecklistsOnCard = function (cardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/checklists', {query: query}, callback);
 };
 
-Trello.prototype.addItemToChecklist = function (checkListId, name, pos, callback) {
+Trello.prototype.addItemToChecklist = function (checkListId, name, pos, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.name = name;
     query.pos = pos;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/checklists/' + checkListId + '/checkitems', {query: query}, callback);
 };
 
-Trello.prototype.updateCard = function (cardId, field, value, callback) {
+Trello.prototype.updateCard = function (cardId, field, value, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = value;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + '/' + field, {query: query}, callback);
 };
 
-Trello.prototype.updateChecklist = function (checklistId, field, value, callback) {
+Trello.prototype.updateChecklist = function (checklistId, field, value, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = value;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/checklists/' + checklistId + '/' + field, {query: query}, callback);
 };
 
-Trello.prototype.updateCardName = function (cardId, name, callback) {
-    return this.updateCard(cardId, 'name', name, callback);
+Trello.prototype.updateCardName = function (cardId, name, extraParamsOrCallback, callback) {
+    return this.updateCard(cardId, 'name', name, extraParamsOrCallback, callback);
 };
 
-Trello.prototype.updateCardDescription = function (cardId, description, callback) {
-    return this.updateCard(cardId, 'desc', description, callback);
+Trello.prototype.updateCardDescription = function (cardId, description, extraParamsOrCallback, callback) {
+    return this.updateCard(cardId, 'desc', description, extraParamsOrCallback, callback);
 };
 
-Trello.prototype.updateCardList = function (cardId, listId, callback) {
-    return this.updateCard(cardId, 'idList', listId, callback);
+Trello.prototype.updateCardList = function (cardId, listId, extraParamsOrCallback, callback) {
+    return this.updateCard(cardId, 'idList', listId, extraParamsOrCallback, callback);
 };
 
-Trello.prototype.getMember = function(memberId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/member/' + memberId, {query: this.createQuery()}, callback);
+Trello.prototype.getMember = function(memberId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/member/' + memberId, {query: query}, callback);
 };
 
-Trello.prototype.getMemberCards = function (memberId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/members/' + memberId + '/cards', {query: this.createQuery()}, callback);
+Trello.prototype.getMemberCards = function (memberId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/members/' + memberId + '/cards', {query: query}, callback);
 };
 
-Trello.prototype.getBoardMembers = function (boardId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/members', {query: this.createQuery()}, callback);
+Trello.prototype.getBoardMembers = function (boardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/members', {query: query}, callback);
 };
 
-Trello.prototype.getOrgMembers = function (organizationId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/organizations/' + organizationId + '/members', {query: this.createQuery()}, callback);
+Trello.prototype.getOrgMembers = function (organizationId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/organizations/' + organizationId + '/members', {query: query}, callback);
 };
 
-Trello.prototype.getListsOnBoard = function (boardId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/lists', {query: this.createQuery()}, callback);
-};
-
-Trello.prototype.getListsOnBoardByFilter = function(boardId, filter, callback) {
-    var query = this.createQuery();
-    query.filter = filter;
+Trello.prototype.getListsOnBoard = function (boardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/lists', {query: query}, callback);
 };
 
-Trello.prototype.getCardsOnBoard = function (boardId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards', {query: this.createQuery()}, callback);
+Trello.prototype.getListsOnBoardByFilter = function(boardId, filter, extraParamsOrCallback, callback) {
+    var query = this.createQuery();
+    query.filter = filter;
+
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/lists', {query: query}, callback);
+};
+
+Trello.prototype.getCardsOnBoard = function (boardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards', {query: query}, callback);
 };
 
 Trello.prototype.getCardsOnBoardWithExtraParams = function (boardId, extraParams, callback) {
-    var query = this.createQuery();    
-    Object.assign(query, extraParams);
-
-    return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards', {query: query}, callback);
+    return this.getCardsOnBoard(boardId, extraParams, callback)
 }
 
-Trello.prototype.getCardsOnList = function (listId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/lists/' + listId + '/cards', {query: this.createQuery()}, callback);
+Trello.prototype.getCardsOnList = function (listId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/lists/' + listId + '/cards', {query: query}, callback);
 };
 
 Trello.prototype.getCardsOnListWithExtraParams = function (listId, extraParams, callback) {
-    var query = this.createQuery();    
-    Object.assign(query, extraParams);
-
-    return makeRequest(rest.get, this.uri + '/1/lists/' + listId + '/cards', {query: query}, callback);
+    return this.getCardsOnList(listId, extraParams, callback)
 }
 
-Trello.prototype.deleteCard = function (cardId, callback) {
-    return makeRequest(rest.del, this.uri + '/1/cards/' + cardId, {query: this.createQuery()}, callback);
+Trello.prototype.deleteCard = function (cardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.del, this.uri + '/1/cards/' + cardId, {query: query}, callback);
 };
 
-Trello.prototype.addWebhook = function (description, callbackUrl, idModel, callback) {
+Trello.prototype.addWebhook = function (description, callbackUrl, idModel, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     var data = {};
 
@@ -296,20 +370,26 @@ Trello.prototype.addWebhook = function (description, callbackUrl, idModel, callb
     data.callbackURL = callbackUrl;
     data.idModel = idModel;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/tokens/' + this.token + '/webhooks/', { data: data, query: query }, callback);
 };
 
-Trello.prototype.deleteWebhook = function (webHookId, callback) {
+Trello.prototype.deleteWebhook = function (webHookId, extraParamsOrCallback, callback) {
     var query = this.createQuery();
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.del, this.uri + '/1/webhooks/' + webHookId, { query: query }, callback);
 };
 
-Trello.prototype.getLabelsForBoard = function(boardId, callback) {
+Trello.prototype.getLabelsForBoard = function(boardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/labels', {query:this.createQuery()}, callback);
 };
 
-Trello.prototype.addLabelOnBoard = function(boardId, name, color, callback) {
+Trello.prototype.addLabelOnBoard = function(boardId, name, color, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     var data = {
         idBoard: boardId,
@@ -317,43 +397,56 @@ Trello.prototype.addLabelOnBoard = function(boardId, name, color, callback) {
         name: name
     };
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri + '/1/labels', {data: data, query:query}, callback);
 };
 
-Trello.prototype.deleteLabel = function(labelId, callback) {
-    return makeRequest(rest.del, this.uri + '/1/labels/' + labelId, {query: this.createQuery()}, callback);
+Trello.prototype.deleteLabel = function(labelId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.del, this.uri + '/1/labels/' + labelId, {query: query}, callback);
 };
 
-Trello.prototype.addLabelToCard = function(cardId, labelId, callback) {
+Trello.prototype.addLabelToCard = function(cardId, labelId, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     var data = { value: labelId };
+    
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri+'/1/cards/' + cardId + '/idLabels', {query:query, data:data}, callback);
 };
 
-Trello.prototype.deleteLabelFromCard = function(cardId, labelId, callback){
-    return makeRequest(rest.del, this.uri + '/1/cards/' + cardId + '/idLabels/'+labelId, {query: this.createQuery()}, callback);
+Trello.prototype.deleteLabelFromCard = function(cardId, labelId, extraParamsOrCallback, callback){
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.del, this.uri + '/1/cards/' + cardId + '/idLabels/'+labelId, {query: query}, callback);
 };
 
-Trello.prototype.updateLabel = function (labelId, field, value, callback) {
+Trello.prototype.updateLabel = function (labelId, field, value, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = value;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/labels/' + labelId + '/' + field, {query: query}, callback);
 };
 
-Trello.prototype.updateLabelName = function (labelId, name, callback) {
-    return this.updateLabel(labelId, 'name', name, callback);
+Trello.prototype.updateLabelName = function (labelId, name, extraParamsOrCallback, callback) {
+    return this.updateLabel(labelId, 'name', name, extraParamsOrCallback, callback);
 };
 
-Trello.prototype.updateLabelColor = function (labelId, color, callback) {
-    return this.updateLabel(labelId, 'color', color, callback);
+Trello.prototype.updateLabelColor = function (labelId, color, extraParamsOrCallback, callback) {
+    return this.updateLabel(labelId, 'color', color, extraParamsOrCallback, callback);
 };
 
-Trello.prototype.getCardStickers = function (cardId, callback) {
-    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/stickers', {query: this.createQuery()}, callback);
+Trello.prototype.getCardStickers = function (cardId, extraParamsOrCallback, callback) {
+    var query = applyExtraParams(extraParamsOrCallback, this.createQuery())
+    callback = extractCallback(extraParamsOrCallback, callback)
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/stickers', {query: query}, callback);
 };
 
-Trello.prototype.addStickerToCard = function(cardId, image, left, top, zIndex, rotate, callback) {
+Trello.prototype.addStickerToCard = function(cardId, image, left, top, zIndex, rotate, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     var data = {
       image: image,
@@ -362,13 +455,17 @@ Trello.prototype.addStickerToCard = function(cardId, image, left, top, zIndex, r
       zIndex: zIndex,
       rotate: rotate,
     };
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.post, this.uri+'/1/cards/' + cardId + '/stickers', {query:query, data:data}, callback);
 };
 
-Trello.prototype.addDueDateToCard = function (cardId, dateValue, callback) {
+Trello.prototype.addDueDateToCard = function (cardId, dateValue, extraParamsOrCallback, callback) {
     var query = this.createQuery();
     query.value = dateValue;
 
+    query = applyExtraParams(extraParamsOrCallback, query)
+    callback = extractCallback(extraParamsOrCallback, callback)
     return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + '/due', {query: query}, callback);
 };
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -229,6 +229,55 @@ describe('Trello', function () {
 
     });
 
+    describe('addCard (with extra params)', function() {
+        var query;
+        var post;
+
+        var extraParams = {
+            due: new Date("2015/03/25"),
+            dueComplete: false
+        };
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'post', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.addCard('name', 'description', 'listId', extraParams, function () {
+                query = restler.post.args[0][1].query;
+                post = restler.post;
+                done();
+            });
+        });
+
+        it('should post to https://api.trello.com/1/cards', function () {
+            post.should.have.been.calledWith('https://api.trello.com/1/cards');
+        });
+
+        it('should include the name', function () {
+            query.name.should.equal('name');
+        });
+
+        it('should include the description', function () {
+            query.desc.should.equal('description');
+        });
+
+        it('should include the due date', function() {
+            query.due.getTime().should.equal((new Date("2015/03/25").getTime()))
+        });
+
+        it('should include the list id', function () {
+            query.idList.should.equal('listId');
+        });
+
+        afterEach(function () {
+            restler.post.restore();
+        });
+
+    });
+
     describe('getCardsOnListWithExtraParams', function () {
         var query;
         var post;
@@ -262,6 +311,39 @@ describe('Trello', function () {
         });
     });
 
+    describe('getCardsOnList (with extra params)', function () {
+        var query;
+        var post;
+
+        var testDate = new Date("2015/03/25");
+        var extraParams = {before: testDate}
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getCardsOnList('listId', extraParams, function () {
+                query = restler.get.args[0][1].query;
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get from https://api.trello.com/1/lists/listId/cards', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/lists/listId/cards');
+        });
+        it('should include a date in the query', function () {
+            query.before.should.equal(testDate)
+        });
+
+        afterEach(function () {
+            restler.get.restore();
+        });
+    });
+
     describe('getCardsOnBoardWithExtraParams', function () {
         var query;
         var post;
@@ -277,6 +359,39 @@ describe('Trello', function () {
             });
 
             trello.getCardsOnBoardWithExtraParams('boardId', extraParams, function () {
+                query = restler.get.args[0][1].query;
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get from https://api.trello.com/1/boards/boardId/cards', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/boards/boardId/cards');
+        });
+        it('should include a date in the query', function () {
+            query.before.should.equal(testDate)
+        });
+
+        afterEach(function () {
+            restler.get.restore();
+        });
+    });
+
+    describe('getCardsOnBoard (with extra params)', function () {
+        var query;
+        var post;
+
+        var testDate = new Date("2015/03/25");
+        var extraParams = {before: testDate}
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getCardsOnBoard('boardId', extraParams, function () {
                 query = restler.get.args[0][1].query;
                 get = restler.get;
                 done();


### PR DESCRIPTION
Addresses #39.

This PR adds the option to adding extra query params to every method without damaging backwards compatibility, by adding an optional `extraParams` argument to every method call (except those that already have one).

The tests have not been modified, and all pass. I will add tests for the new style too.