### PR TITLE
Add functionality to query card without board id

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,6 +135,10 @@ Trello.prototype.getCard = function (boardId, cardId, callback) {
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards/' + cardId, {query: this.createQuery()}, callback);
 };
 
+Trello.prototype.getCardWithoutBoardId = function (cardId, callback) {
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId, {query: this.createQuery()}, callback);
+};
+
 Trello.prototype.getCardsForList = function(listId, actions, callback) {
     var query = this.createQuery();
     if (actions)


### PR DESCRIPTION
You can't allways assume we have the board id of a single card.
Trello supports this kind of functionality, and i find it very
difficulty to understand why shouldn't this aswell. New function
"getCardWithoutBoardId" only takes cardId + callback, for convinience.