### PR TITLE
Add copyBoard functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ API calls can either execute a callback or return a promise. To return a promise
 * addMemberToCard 
 * addStickerToCard 
 * addWebhook 
+* copyBoard
 
 ### Delete
 

--- a/main.js
+++ b/main.js
@@ -103,6 +103,14 @@ Trello.prototype.addBoard = function (name, description, organizationId, callbac
     return makeRequest(rest.post, this.uri + '/1/boards/', {query: query}, callback);
 };
 
+Trello.prototype.copyBoard = function (name, sourceBoardId, callback) {
+    var query = this.createQuery();
+    query.name = name;
+    query.idBoardSource = sourceBoardId;
+
+    return makeRequest(rest.post, this.uri + '/1/boards/', {query: query}, callback);
+};
+
 Trello.prototype.updateBoardPref = function (boardId, field, value, callback) {
     var query = this.createQuery();
     query.value = value;

--- a/test/spec.js
+++ b/test/spec.js
@@ -140,6 +140,42 @@ describe('Trello', function () {
         });
     });
 
+    describe('copyBoard', function () {
+        var query;
+        var post;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'post', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.copyBoard('name', 'sourceBoardId', function () {
+                query = restler.post.args[0][1].query;
+                post = restler.post;
+                done();
+            });
+
+        });
+
+        it('should post to https://api.trello.com/1/boards/', function () {
+            post.should.have.been.calledWith('https://api.trello.com/1/boards/');
+        });
+
+        it('should include the name', function () {
+            query.name.should.equal('name');
+        });
+
+        it('should include the source board id', function () {
+            query.idBoardSource.should.equal('sourceBoardId');
+        });
+
+        afterEach(function () {
+            restler.post.restore();
+        });
+    });
+
     describe('addCard', function() {
         var query;
         var post;


### PR DESCRIPTION
This is not a separate resource in the API.  Rather, if you include a source board ID in the post request for creating a board (same as used by the addBoard function) then that board will be used as a base to copy for the new one.  Because its parameters have very little overlap with the existing addBoard function it seemed more semantic to create a new function for copying boards.

This resolves #80.

API docs: https://developers.trello.com/reference#boardsid