### PR TITLE
Allow options to be passed into public-facing makeRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ API calls can either execute a callback or return a promise. To return a promise
 ```javascript
     // Get all registered tokens and webhooks
     // Url will look like: https://api.trello.com/1/members/me/tokens?webhooks=true&key=YOURKEY&token=YOURTOKEN
-    trello.makeRequest('get', '/1/members/me/tokens', { webhooks: true })
+    trello.makeRequest('get', '/1/members/me/tokens', { query: { webhooks: true } })
       .then((res) => {
           console.log(res)
       });

--- a/main.js
+++ b/main.js
@@ -87,8 +87,8 @@ Trello.prototype.makeRequest = function (requestMethod, path, options, callback)
         throw new Error("Unsupported requestMethod. Pass one of these methods: POST, GET, PUT, DELETE.");
     }
     var keyTokenObj = this.createQuery();
-    var query = objectAssign({}, options, keyTokenObj);
-    return makeRequest(methods[method], this.uri + path, {query: query}, callback)
+    options.query = objectAssign({}, options.query, keyTokenObj);
+    return makeRequest(methods[method], this.uri + path, options, callback)
 };
 
 Trello.prototype.addBoard = function (name, description, organizationId, callback) {


### PR DESCRIPTION
Was scratching my head for about an hour figuring out why file attachment would not upload if I tried invoking card attachment endpoint with file buffer attachment using `makeRequest`. (`addAttachmentToCard` method in this library only supports urls so I couldn't use it)

Discovered it was because `multipart` and `data` fields, expected by `restler`, are discarded when passed in `makeRequest`. (only `query` arguments remain)

Updated `makeRequest` to accept `options` as-is, and injects key and token into query field.