### PR TITLE
Update getCard to not require boardId

### DIFF
--- a/main.js
+++ b/main.js
@@ -140,7 +140,7 @@ Trello.prototype.addCardWithExtraParams = function(name, extraParams, listId, ca
 };
 
 Trello.prototype.getCard = function (boardId, cardId, callback) {
-    if(!boardId) 
+    if(boardId === null)
         return makeRequest(rest.get, this.uri + '/1/cards/' + cardId, {query: this.createQuery()}, callback);
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards/' + cardId, {query: this.createQuery()}, callback);
 };

--- a/main.js
+++ b/main.js
@@ -140,6 +140,8 @@ Trello.prototype.addCardWithExtraParams = function(name, extraParams, listId, ca
 };
 
 Trello.prototype.getCard = function (boardId, cardId, callback) {
+    if(!boardId) 
+        return makeRequest(rest.get, this.uri + '/1/cards/' + cardId, {query: this.createQuery()}, callback);
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards/' + cardId, {query: this.createQuery()}, callback);
 };
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -265,6 +265,62 @@ describe('Trello', function () {
 
     });
 
+    describe('getCard', function() {
+        var query;
+        var post;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getCard(null, 'cardId', function () {
+                query = restler.get.args[0][1].query;
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get https://api.trello.com/1/cards/cardId', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/cards/cardId');
+        });
+
+        afterEach(function () {
+            restler.get.restore();
+        });
+
+    });
+
+    describe('getCardFromBoard', function() {
+        var query;
+        var post;
+
+        beforeEach(function (done) {
+            sinon.stub(restler, 'get', function (uri, options) {
+                return {once: function (event, callback) {
+                    callback(null, null);
+                }};
+            });
+
+            trello.getCard('boardId', 'cardId', function () {
+                query = restler.get.args[0][1].query;
+                get = restler.get;
+                done();
+            });
+        });
+
+        it('should get https://api.trello.com/1/boards/boardId/cards/cardId', function () {
+            get.should.have.been.calledWith('https://api.trello.com/1/boards/boardId/cards/cardId');
+        });
+
+        afterEach(function () {
+            restler.get.restore();
+        });
+
+    });
+
     describe('getCardsOnListWithExtraParams', function () {
         var query;
         var post;


### PR DESCRIPTION
Usage:

```js
// old way (still works)
trello.getCard('boardId', 'cardId')

// new way
trello.getCard(null, 'cardId')
```