### PR TITLE
Added support for custom fields to be updated

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,6 +234,10 @@ Trello.prototype.getChecklistsOnCard = function (cardId, callback) {
     return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/checklists', {query: this.createQuery()}, callback);
 };
 
+Trello.prototype.getActionsOnCard = function (cardId, callback) {
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/actions', {query: this.createQuery()}, callback);
+};
+
 Trello.prototype.addItemToChecklist = function (checkListId, name, pos, callback) {
     var query = this.createQuery();
     query.name = name;
@@ -424,6 +428,10 @@ Trello.prototype.updateCustomFieldOnCard = function (cardId, field, value, callb
 
 Trello.prototype.getCustomFieldsOnCard = function (cardId, callback) {
     return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/customFieldItems', {query: this.createQuery()}, callback);
+};
+
+Trello.prototype.getAttachmentsOnCard = function (cardId, callback) {
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/attachments', {query: this.createQuery()}, callback);
 };
 
 

--- a/main.js
+++ b/main.js
@@ -155,6 +155,10 @@ Trello.prototype.getCard = function (boardId, cardId, callback) {
     return makeRequest(rest.get, this.uri + '/1/boards/' + boardId + '/cards/' + cardId, {query: this.createQuery()}, callback);
 };
 
+Trello.prototype.getCardById = function (cardId, callback) {
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId, {query: this.createQuery()}, callback);
+};
+
 Trello.prototype.getCardsForList = function(listId, actions, callback) {
     var query = this.createQuery();
     if (actions)
@@ -418,6 +422,9 @@ Trello.prototype.updateCustomFieldOnCard = function (cardId, field, value, callb
     return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + /customField/ + field + '/item', options, callback);
 };
 
+Trello.prototype.getCustomFieldsOnCard = function (cardId, callback) {
+    return makeRequest(rest.get, this.uri + '/1/cards/' + cardId + '/customFieldItems', {query: this.createQuery()}, callback);
+};
 
 
 module.exports = Trello;

--- a/main.js
+++ b/main.js
@@ -409,5 +409,15 @@ Trello.prototype.addDueDateToCard = function (cardId, dateValue, callback) {
     return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + '/due', {query: query}, callback);
 };
 
+Trello.prototype.updateCustomFieldOnCard = function (cardId, field, value, callback) {
+    var options = {
+        query : this.createQuery(),
+        headers : {'Content-Type' : 'application/json'},
+        data : { value : value}
+    };
+    return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + /customField/ + field + '/item', options, callback);
+};
+
+
 
 module.exports = Trello;

--- a/main.js
+++ b/main.js
@@ -423,7 +423,7 @@ Trello.prototype.updateCustomFieldOnCard = function (cardId, field, value, callb
         headers : {'Content-Type' : 'application/json'},
         data : { value : value}
     };
-    return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + /customField/ + field + '/item', options, callback);
+    return makeRequest(rest.put, this.uri + '/1/cards/' + cardId + '/customField/' + field + '/item', options, callback);
 };
 
 Trello.prototype.getCustomFieldsOnCard = function (cardId, callback) {

--- a/main.js
+++ b/main.js
@@ -78,19 +78,31 @@ Trello.prototype.makeRequest = function (requestMethod, path, options, callback)
     var method = requestMethod.toLowerCase();
     var methods = {
         'post': rest.post,
+        'postjson': rest.post,
         'get': rest.get,
         'put': rest.put,
+        'putjson' : rest.put,
         'delete': rest.del
     };
 
     if (!methods[method]) {
         throw new Error("Unsupported requestMethod. Pass one of these methods: POST, GET, PUT, DELETE.");
     }
+
     var keyTokenObj = this.createQuery();
     var query = objectAssign({}, options, keyTokenObj);
-    return makeRequest(methods[method], this.uri + path, {query: query}, callback)
-};
 
+    if(method.indexOf('json') !== -1) {
+        var jsonOptions = {};
+        jsonOptions.headers = {'Content-Type' : 'application/json'}
+        jsonOptions.data = options.data;
+        jsonOptions.query = query;
+        delete options.data;
+        return makeRequest(methods[method], this.uri + path, jsonOptions, callback)
+    } else {
+        return makeRequest(methods[method], this.uri + path, {query: query}, callback)
+    }
+};
 Trello.prototype.addBoard = function (name, description, organizationId, callback) {
     var query = this.createQuery();
     query.name = name;


### PR DESCRIPTION
Added a fix for #76 by adding the function updateCustomFieldOnCard.
The issue was because of the requirements of the post body for custom fields. It differs from the other implemented endpoints. I had to change the structure of the options object for Restler to make it work.

I Also added the putjson and postjson raw options to the makeRequest public function. This is to add raw support for any API endpoints that are still unsupported for the same reason that custom fields were.